### PR TITLE
Arbidex IFO subgraph

### DIFF
--- a/savvy-arbi-frens/package.json
+++ b/savvy-arbi-frens/package.json
@@ -5,6 +5,7 @@
     "codegen": "graph codegen",
     "build": "graph build",
     "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ savvy-arbi-frens",
+    "deploy-ifo": "graph deploy --node https://api.studio.thegraph.com/deploy/ savvy-ifo-arbi",
     "create-local": "graph create --node http://localhost:8020/ savvy-arbi-frens",
     "remove-local": "graph remove --node http://localhost:8020/ savvy-arbi-frens",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 savvy-arbi-frens",

--- a/savvy-arbi-frens/schema.graphql
+++ b/savvy-arbi-frens/schema.graphql
@@ -9,4 +9,5 @@ type User @entity {
   everHeldRAM: Boolean!
   everHeldGRAIL: Boolean!
   everHeldGMD: Boolean!
+  everHeldARX: Boolean!
 }

--- a/savvy-arbi-frens/src/tokens.ts
+++ b/savvy-arbi-frens/src/tokens.ts
@@ -7,6 +7,7 @@ import { Transfer as TransferEventWMEMO } from "../generated/WMEMO/WMEMO";
 import { Transfer as TransferEventRAM } from "../generated/RAM/RAM";
 import { Transfer as TransferEventGRAIL } from "../generated/GRAIL/GRAIL";
 import { Transfer as TransferEventGMD } from "../generated/GMD/GMD";
+import { Transfer as TransferEventARX } from "../generated/ARX/ARX";
 import { User } from "../generated/schema";
 
 function getUser(address: string): User {
@@ -22,6 +23,7 @@ function getUser(address: string): User {
     user.everHeldRAM = false;
     user.everHeldGRAIL = false;
     user.everHeldGMD = false;
+    user.everHeldARX = false;
   }
   return user;
 }
@@ -77,5 +79,11 @@ export function handleTransferGRAIL(event: TransferEventGRAIL): void {
 export function handleTransferGMD(event: TransferEventGMD): void {
   const user = getUser(event.params.to.toHexString());
   user.everHeldGMD = true;
+  user.save();
+}
+
+export function handleTransferARX(event: TransferEventARX): void {
+  const user = getUser(event.params.to.toHexString());
+  user.everHeldARX = true;
   user.save();
 }

--- a/savvy-arbi-frens/subgraph.yaml
+++ b/savvy-arbi-frens/subgraph.yaml
@@ -182,3 +182,23 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransferGMD
       file: ./src/tokens.ts
+  - kind: ethereum
+    name: ARX
+    network: arbitrum-one
+    source:
+      address: "0xD5954c3084a1cCd70B4dA011E67760B8e78aeE84"
+      abi: ARX
+      startBlock: 60000000
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Transfer
+      abis:
+        - name: ARX
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransferARX
+      file: ./src/tokens.ts


### PR DESCRIPTION
Add subgraph logic for Arbidex token (ARX).

Created a new subgraph because sync takes over 24 hours and did not want to affect existing subgraph calls. 

Already deployed: https://thegraph.com/studio/subgraph/savvy-ifo-arbi/